### PR TITLE
Update dbt version

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,0 @@
-FROM gitpod/workspace-postgres
-
-RUN pip install \
-    dbt-core==1.6.1 \
-    dbt-postgres==1.6.1 \
-    dbt-redshift==1.6.1 \
-    dbt-snowflake==1.6.2

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/dbt-labs/snowflake:latest
+image: ghcr.io/dbt-labs/dbt-snowflake:1.8.3
 tasks:
   - command: mkdir -p /workspace/.dbt && ln -snf /workspace/.dbt ~/.dbt
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,4 @@
-image:
-  file: .gitpod.Dockerfile
+image: ghcr.io/dbt-labs/snowflake:latest
 tasks:
   - command: mkdir -p /workspace/.dbt && ln -snf /workspace/.dbt ~/.dbt
 ports:
@@ -7,5 +6,3 @@ ports:
     onOpen: open-browser
   - port: 8081
     onOpen: open-preview
-  - port: 5432
-    onOpen: ignore

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 Template repository for the projects and environment of the course: Analytics engineering with dbt
 
-> Please note that this sets some environment variables so if you create some new terminals please load them again.
+# Updating dbt version
+
+To update dbt version you need to edit `.gitpod.yml` file and put a specific verion of dbt adapter you want to use:
+
+```yaml
+image: ghcr.io/dbt-labs/dbt-snowflake:1.8.3. # update version here
+...
+```
+
+If you run `dbt --version` you may see that dbt-core might be slightly behind the latest version, but that's fine as soon as adapter version is up-to-date.
+
 
 ## License
 GPL-3.0


### PR DESCRIPTION
Updated the repository to include the latest version of dbt:
- `gitpod.yml` now uses official dbt Docker image
- removed old Dockerfile
- added a short description on how to update the version in the future